### PR TITLE
feat(auth): Add signup, login, forgot password and pet password page

### DIFF
--- a/app/(features)/auth/forgot-password/page.tsx
+++ b/app/(features)/auth/forgot-password/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+import React from "react";
+import Image from "next/image";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+const ForgotPassword = () => {
+  const router = useRouter();
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    router.push("/auth/set-password");
+  };
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md p-8 bg-white rounded-xl shadow-lg border border-gray-200">
+        <div className="flex flex-col items-center">
+          <Image
+            src="/a2svlogo(blue).png"
+            alt="A2SV Logo"
+            width={160}
+            height={160}
+            className="mb-2"
+            priority
+          />
+        </div>
+        <h2 className="text-2xl font-semibold text-center mb-1 text-black">
+          Forgot your password?
+        </h2>
+        <div className="flex justify-center text-sm mb-6">
+          <p className="text-center text-gray-500">
+            Enter your email and we'll send you a link to get back into your
+            account.
+          </p>
+          <div style={{ borderRight: "1px solid #4F46E5" }}></div>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <input
+              type="email"
+              placeholder="Email address"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="username"
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full py-2 mt-2 bg-[#4F46E5] text-white font-semibold rounded-lg transition-colors cursor-pointer"
+          >
+            Sign in
+          </button>
+          <Link href="/auth/login">
+            <button className="w-full text-[#4F46E5]  font-semibold rounded-lg transition-colors cursor-pointer">
+              Back to login
+            </button>
+          </Link>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/app/(features)/auth/login/page.tsx
+++ b/app/(features)/auth/login/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+const Login = () => {
+  const router = useRouter();
+  const handleSubmit = () => {
+    // router.push("/auth/login");
+  };
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md p-8 bg-white rounded-xl shadow-lg border border-gray-200">
+        <div className="flex flex-col items-center">
+          <Image
+            src="/a2svlogo(blue).png"
+            alt="A2SV Logo"
+            width={160}
+            height={160}
+            className="mb-2"
+            priority
+          />
+        </div>
+        <h2 className="text-2xl font-semibold text-center mb-1 text-black">
+          Sign in to your account
+        </h2>
+        <div className="flex justify-center text-sm mb-6">
+          <Link href="/" className="hover:underline mr-1 text-[#4F46E5]">
+            Back to Home
+          </Link>
+          <div style={{ borderRight: "1px solid #4F46E5" }}></div>
+          <Link
+            href="/auth/signup"
+            className="hover:underline ml-1 text-[#4F46E5]"
+          >
+            Create a new applicant account
+          </Link>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <input
+              type="email"
+              placeholder="user@example.com"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="username"
+            />
+          </div>
+          <div>
+            <input
+              type="password"
+              placeholder="password123"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <label className="flex items-center text-sm">
+              <input
+                type="checkbox"
+                className="mr-2 cursor-pointer"
+                style={{ accentColor: "#4F46E5" }}
+              />
+              <p className="text-black">Remember me</p>
+            </label>
+            <Link
+              href="/auth/forgot-password"
+              className="hover:underline text-sm text-[#4F46E5]"
+            >
+              Forgot your password?
+            </Link>
+          </div>
+          <button
+            type="submit"
+            className="w-full py-2 mt-2 bg-[#4F46E5] text-white font-semibold rounded-lg transition-colors cursor-pointer"
+          >
+            Sign in
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/app/(features)/auth/set-password/page.tsx
+++ b/app/(features)/auth/set-password/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+import React from "react";
+import Image from "next/image";
+
+import { useRouter } from "next/navigation";
+
+const SetPassword = () => {
+  const router = useRouter();
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    router.push("/auth/login");
+  };
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md p-8 bg-white rounded-xl shadow-lg border border-gray-200">
+        <div className="flex flex-col items-center">
+          <Image
+            src="/a2svlogo(blue).png"
+            alt="A2SV Logo"
+            width={160}
+            height={160}
+            className="mb-2"
+            priority
+          />
+        </div>
+        <h2 className="text-2xl font-semibold text-center mb-1 text-black">
+          Set a new password
+        </h2>
+        <div className="flex justify-center text-sm mb-6">
+          <p className="text-center text-gray-500">
+            Please choose a strong, new password for your account.
+          </p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <input
+              type="password"
+              placeholder="New Password"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+          <div>
+            <input
+              type="password"
+              placeholder="Confirm New Password"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full py-2 mt-2 bg-[#4F46E5] text-white font-semibold rounded-lg transition-colors cursor-pointer"
+          >
+            Update Password
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SetPassword;

--- a/app/(features)/auth/signup/page.tsx
+++ b/app/(features)/auth/signup/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+const Signup = () => {
+  const router = useRouter();
+  const handleSubmit = () => {
+    router.push("/");
+  };
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md p-8 bg-white rounded-xl shadow-lg border border-gray-200">
+        <div className="flex flex-col items-center">
+          <Image
+            src="/a2svlogo(blue).png"
+            alt="A2SV Logo"
+            width={160}
+            height={160}
+            className="mb-2"
+            priority
+          />
+        </div>
+        <h2 className="text-2xl font-semibold text-center mb-1 text-black">
+          Create a new applicant account
+        </h2>
+        <div className="flex justify-center text-sm mb-6">
+          <p className="text-gray-900">Or </p>
+          <Link
+            href="/auth/login"
+            className="hover:underline ml-1 text-[#4F46E5]"
+          >
+            sign in to your existing account
+          </Link>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <input
+              type="text"
+              placeholder="Full name"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="username"
+            />
+          </div>
+          <div>
+            <input
+              type="email"
+              placeholder="Email address"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="username"
+            />
+          </div>
+          <div>
+            <input
+              type="password"
+              placeholder="Password"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+          <div>
+            <input
+              type="password"
+              placeholder="Confirm Password"
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 placeholder-gray-500 text-black"
+              style={{ "--tw-ring-color": "#4F46E5" } as React.CSSProperties}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full py-2 mt-2 bg-[#4F46E5] text-white font-semibold rounded-lg transition-colors cursor-pointer"
+          >
+            Create account
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Signup;


### PR DESCRIPTION
This pull request introduces new pages for the authentication flow, including login, signup, forgot password, and set password screens. Each page features a modern, user-friendly design with form validation, navigation. The pages leverage Next.js routing and styling conventions to provide a cohesive user experience.

**New authentication pages:**

* Added a `login` page with email and password fields, "remember me" option, and navigation links for password recovery and account creation.
* Added a `signup` page with fields for full name, email, password, and password confirmation, as well as a link to sign in for existing users.
* Added a `forgot-password` page allowing users to request a password reset by entering their email, with navigation back to the login page.
* Added a `set-password` page for users to set a new password, including password and confirm password fields, and navigation back to login upon completion.